### PR TITLE
Add user-follow-read scope to allow getting followed artists

### DIFF
--- a/src/meta_pipe.rs
+++ b/src/meta_pipe.rs
@@ -94,7 +94,7 @@ struct MetaPipeThread {
     spirc: Arc<Spirc>,
 }
 
-const SCOPES: &str = "streaming,user-read-playback-state,user-modify-playback-state,user-read-currently-playing,user-read-private,user-library-modify,user-top-read,user-read-recently-played,user-library-read,playlist-read-private,playlist-read-collaborative";
+const SCOPES: &str = "streaming,user-read-playback-state,user-modify-playback-state,user-read-currently-playing,user-read-private,user-library-modify,user-top-read,user-read-recently-played,user-library-read,playlist-read-private,playlist-read-collaborative,user-follow-read";
 const CLIENT_ID: Option<&'static str> = option_env!("CLIENT_ID");
 
 #[derive(Debug)]


### PR DESCRIPTION
I am making modification of spotify volumio plugin and possibility [to access the followed artists](https://developer.spotify.com/documentation/web-api/concepts/scopes#user-follow-read). But there is no required scope for that in your lib.

So this is the missing scope.

Or please describe how to compile this library locally via docker image? What image to use and what commands to run? I will use it with my plugin then. I tried to follow https://www.docker.com/blog/cross-compiling-rust-code-for-multiple-architectures/ but no luck still... :pray: 